### PR TITLE
ci: install nargo using noirup

### DIFF
--- a/.github/workflows/noir.yml
+++ b/.github/workflows/noir.yml
@@ -15,13 +15,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Install nargo 0.6.0
-        run: |
-          mkdir -p $HOME/.nargo/bin
-          curl -o $HOME/.nargo/bin/nargo-x86_64-unknown-linux-gnu.tar.gz -L https://github.com/noir-lang/noir/releases/download/v0.6.0/nargo-x86_64-unknown-linux-gnu.tar.gz
-          tar -xvf $HOME/.nargo/bin/nargo-x86_64-unknown-linux-gnu.tar.gz -C $HOME/.nargo/bin/
-          echo -e '\nexport PATH=$PATH:$HOME/.nargo/bin' >> ~/.bashrc
-          echo "${HOME}/.nargo/bin" >> $GITHUB_PATH
+      - name: Install Nargo
+        uses: noir-lang/noirup@v0.1.2
+        with:
+          toolchain: v0.6.0
 
       - name: Run nargo test
         run: |


### PR DESCRIPTION
We've got a github action to install nargo, I've switched over to use this.