### PR TITLE
fixed stuff for noir 0.6.0

### DIFF
--- a/src/secp256k1.nr
+++ b/src/secp256k1.nr
@@ -35,7 +35,7 @@ impl PubKey {
 
     fn verify_sig(self, signature: [u8; 64], hashed_message: [u8; 32]) -> bool {
         let isValid = std::ecdsa_secp256k1::verify_signature(self.pub_x, self.pub_y, signature, hashed_message);
-        isValid == true
+        isValid
     }
 
     fn to_eth_address(self) -> Field {

--- a/src/secp256k1.nr
+++ b/src/secp256k1.nr
@@ -16,26 +16,26 @@ impl PubKey {
     }
 
     fn from_unified(pub_key: [u8; 64]) -> PubKey {
-        let keys = helpers::split_pub_key(pub_key);
+        let (key_x, key_y) = helpers::split_pub_key(pub_key);
 
         PubKey {
-            pub_x: keys[0],
-            pub_y: keys[1],
+            pub_x: key_x,
+            pub_y: key_y,
         }
     }
 
     fn from_uncompressed(pub_key: [u8; 65]) -> PubKey {
-        let keys = helpers::split_uncompressed_pub_key(pub_key);
+        let (key_x, key_y) = helpers::split_uncompressed_pub_key(pub_key);
 
         PubKey {
-            pub_x: keys[0],
-            pub_y: keys[1],
+            pub_x: key_x,
+            pub_y: key_y,
         }
     }
 
     fn verify_sig(self, signature: [u8; 64], hashed_message: [u8; 32]) -> bool {
         let isValid = std::ecdsa_secp256k1::verify_signature(self.pub_x, self.pub_y, signature, hashed_message);
-        isValid == 1
+        isValid == true
     }
 
     fn to_eth_address(self) -> Field {

--- a/src/secp256k1.nr
+++ b/src/secp256k1.nr
@@ -35,7 +35,7 @@ impl PubKey {
 
     fn verify_sig(self, signature: [u8; 64], hashed_message: [u8; 32]) -> bool {
         let isValid = std::ecdsa_secp256k1::verify_signature(self.pub_x, self.pub_y, signature, hashed_message);
-        isValid
+        isValid == 1
     }
 
     fn to_eth_address(self) -> Field {

--- a/src/secp256k1/helpers.nr
+++ b/src/secp256k1/helpers.nr
@@ -162,31 +162,31 @@ fn test_u8_32_to_u160() {
 unconstrained
 fn split_pub_key(
     pub_key: [u8; 64]
-) -> [[u8; 32]; 2] {
+) -> ([u8; 32], [u8; 32]) {
     let mut pub_key_x: [u8; 32] = [0; 32];
     let mut pub_key_y: [u8; 32] = [0; 32];
 
     for i in 0..32 {
         pub_key_x[i] = pub_key[i];
         pub_key_y[i] = pub_key[i + 32];
-    }
+    };
 
-    [pub_key_x, pub_key_y]
+    (pub_key_x, pub_key_y)
 }
 
 unconstrained
 fn split_uncompressed_pub_key(
     pub_key: [u8; 65]
-) -> [[u8; 32]; 2] {
+) -> ([u8; 32], [u8; 32]) {
     let mut pub_key_x: [u8; 32] = [0; 32];
     let mut pub_key_y: [u8; 32] = [0; 32];
 
     for i in 0..32 {
         pub_key_x[i] = pub_key[i + 1];
         pub_key_y[i] = pub_key[i + 32 + 1];
-    }
+    };
 
-    [pub_key_x, pub_key_y]
+    (pub_key_x, pub_key_y)
 }
 
 


### PR DESCRIPTION
0.6.0 complained about two things:

- can't compare the result of sig verification with 1, it's a bool now
- complains about nested arrays when returning `[pub_x, pub_y]`, since those are arrays too

fixed the bool, and fixed the return to be a tuple instead