### PR TITLE
Removing pub keyword on return value

### DIFF
--- a/src/lib.nr
+++ b/src/lib.nr
@@ -7,7 +7,7 @@ fn ecrecover(
     pub_key_y: [u8; 32],
     signature: [u8; 64], // clip v value
     hashed_message: [u8; 32]
-) -> pub Field {
+) -> Field {
     let key = secp256k1::PubKey::from_xy(pub_key_x, pub_key_y);
 
     assert(key.verify_sig(signature, hashed_message));


### PR DESCRIPTION
Getting this error

```
error: unnecessary pub keyword on return type for function ecrecover
  ┌─ /Users/zpedro/nargo/github.com/colinnielsen/ecrecover-noir.gitv0.9.0/src/lib.nr:5:4
  │
5 │ fn ecrecover(
  │    --------- unnecessary pub return type
  │
  = The `pub` keyword only has effects on arguments to the entry-point function of a program. Thus, adding it to other function parameters can be deceiving and should be removed

Error: Aborting due to 1 previous error

Location:
    crates/nargo_cli/src/cli/mod.rs:74:5
```

I'm removing the `pub` keyword so it passes