### PR TITLE
Fix compiling issues

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -6,4 +6,4 @@ notes = "AMDG"
 type = "lib"
 
 [dependencies]
-array_helpers = { tag = "v0.1.1", git = "https://github.com/haythemsellami/noir-array-helpers" }
+array_helpers = { tag = "v0.1.2", git = "https://github.com/haythemsellami/noir-array-helpers" }

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -2,7 +2,6 @@
 name = "ecrecover"
 authors = ["@colinnielsen"]
 compiler_version = "0.9.0"
-name = "ecrecover"
 notes = "AMDG"
 type = "lib"
 

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -1,8 +1,10 @@
 [package]
+name = "ecrecover"
 authors = ["@colinnielsen"]
 compiler_version = "0.9.0"
 name = "ecrecover"
 notes = "AMDG"
+type = "lib"
 
 [dependencies]
 array_helpers = { tag = "v0.1.0", git = "https://github.com/colinnielsen/noir-array-helpers" }

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -6,4 +6,4 @@ notes = "AMDG"
 type = "lib"
 
 [dependencies]
-array_helpers = { tag = "v0.1.0", git = "https://github.com/colinnielsen/noir-array-helpers" }
+array_helpers = { tag = "v0.1.1", git = "https://github.com/haythemsellami/noir-array-helpers" }


### PR DESCRIPTION
Fix compiling issues when running with `nargo 0.10.1 (git version hash: ba8ffd84c19b3516334c126bc2f25c725985baa3, is dirty: false)`

May need to re-use the upstream `colinnielsen/noir-array-helpers` lib when the PR there is merged.