### PR TITLE
build: Enable building with Noir compiler >=0.19.0

### DIFF
--- a/.github/workflows/noir.yml
+++ b/.github/workflows/noir.yml
@@ -17,9 +17,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Nargo
-        uses: noir-lang/noirup@v0.1.2
+        uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: v0.10.1
+          toolchain: v0.19.0
 
       - name: Run nargo test
         run: |

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -6,4 +6,4 @@ notes = "AMDG"
 type = "lib"
 
 [dependencies]
-array_helpers = { tag = "v0.10.0", git = "https://github.com/colinnielsen/noir-array-helpers" }
+array_helpers = { tag = "v0.19.0", git = "https://github.com/colinnielsen/noir-array-helpers" }

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["@colinnielsen"]
-compiler_version = "0.10.1"
+compiler_version = ">=0.10.1"
 name = "ecrecover"
 notes = "AMDG"
 type = "lib"

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["@colinnielsen"]
-compiler_version = ">=0.10.1"
+compiler_version = ">=0.19.0"
 name = "ecrecover"
 notes = "AMDG"
 type = "lib"


### PR DESCRIPTION
This just enables compilation with later compiler versions. As of Noir compiler v0.19.0, it will validate the `compiler_version` is compatible, and it requires `>=` to compiler with later versions.

**NOTE:** This requires the pull request on the `noir-array-helpers` to be merged to actually compile with >=0.19.0. However, just merging this PR shouldn't break anything.

https://github.com/colinnielsen/noir-array-helpers/pull/8