### PR TITLE
keccak256 has moved out of std

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -7,3 +7,4 @@ type = "lib"
 
 [dependencies]
 array_helpers = { tag = "v0.30.0", git = "https://github.com/colinnielsen/noir-array-helpers" }
+keccak256 = { tag = "v0.1.0", git = "https://github.com/noir-lang/keccak256" }

--- a/src/secp256k1.nr
+++ b/src/secp256k1.nr
@@ -1,4 +1,4 @@
-use dep::std;
+use dep::keccak256;
 use dep::array_helpers;
 
 pub struct PubKey {
@@ -53,7 +53,7 @@ impl PubKey {
 
     pub fn to_eth_address(self) -> Field {
         let pub_key = array_helpers::u8_32_to_u8_64(self.pub_x, self.pub_y);
-        let hashed_pub_key = std::hash::keccak256(pub_key, 64);
+        let hashed_pub_key = keccak256::keccak256(pub_key, 64);
 
         let mut addr: Field = 0;
         for i in 0..20 {


### PR DESCRIPTION
keccak256 is no longer in the standard library; instead, we should use the keccak256 external dependency to prevent this repo from being unusable for newer versions of Noir than 1.0.0-beta.3

Fixes issue #17 

Ref: https://github.com/noir-lang/keccak256/tree/main