### PR TITLE
Update array_helpers dependency to v0.30.2

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -6,5 +6,5 @@ notes = "AMDG"
 type = "lib"
 
 [dependencies]
-array_helpers = { tag = "v0.30.0", git = "https://github.com/colinnielsen/noir-array-helpers" }
+array_helpers = { tag = "v0.30.2", git = "https://github.com/colinnielsen/noir-array-helpers" }
 keccak256 = { tag = "v0.1.0", git = "https://github.com/noir-lang/keccak256" }


### PR DESCRIPTION
This is necessary to support higher versions of Noir (1.0.0-beta14, for example).